### PR TITLE
Bug fix related to input of DenovoSig

### DIFF
--- a/musical/denovo.py
+++ b/musical/denovo.py
@@ -539,6 +539,8 @@ class DenovoSig:
                 ):
         if (type(X) != np.ndarray) or (not np.issubdtype(X.dtype, np.floating)):
             self.X = np.array(X).astype(float)
+        else:
+            self.X = X
         self.n_features, self.n_samples = self.X.shape
         if isinstance(X, pd.DataFrame):
             self.X_df = X.astype(float)


### PR DESCRIPTION
There are cases when X is not passed to self.X. This bug was introduced in https://github.com/parklab/MuSiCal/commit/c9dd54f41a9a0c7a8a8f64569379a2d6b182f672. Now fixed.